### PR TITLE
Fixed incorrect usage of `get` from `get_config`

### DIFF
--- a/HashmobAPI.py
+++ b/HashmobAPI.py
@@ -14,12 +14,7 @@ def get_config(config_path):
         with open(config_path) as file:
             return json.load(file)
     else:
-        return {
-            'potfile_path': None,
-            'api_key': None,
-            'resubmission_delay': None,
-            'previous_size': None
-        }
+        return {}
 
 
 def update_config(config_data, config_path):


### PR DESCRIPTION
Previously, I was passing `None` in the default dictionary return from `get_config` as I misremembered how `dict.get` behaves. I am now returning an empty dict so it works correctly.